### PR TITLE
Issue #15: Refresh project on build completion

### DIFF
--- a/dev/com.ibm.microclimate.core/src/com/ibm/microclimate/core/internal/MCEclipseApplication.java
+++ b/dev/com.ibm.microclimate.core/src/com/ibm/microclimate/core/internal/MCEclipseApplication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -289,6 +289,28 @@ public class MCEclipseApplication extends MicroclimateApplication {
 			return capabilities.supportsDebugMode() && capabilities.canRestart();
 		}
 		return false;
+	}
+
+	@Override
+	public void buildComplete() {
+		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(name);
+    	if (project != null && project.isAccessible()) {
+    		Job job = new Job(NLS.bind(Messages.RefreshResourceJobLabel, project.getName())) {
+				@Override
+				protected IStatus run(IProgressMonitor monitor) {
+					try {
+						project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
+			            return Status.OK_STATUS;
+					} catch (Exception e) {
+						MCLogger.logError("An error occurred while refreshing the resource: " + project.getLocation()); //$NON-NLS-1$
+						return new Status(IStatus.ERROR, MicroclimateCorePlugin.PLUGIN_ID,
+								NLS.bind(Messages.RefreshResourceError, project.getLocation()), e);
+					}
+				}
+			};
+			job.setPriority(Job.LONG);
+			job.schedule();
+    	}
 	}
     
 }

--- a/dev/com.ibm.microclimate.core/src/com/ibm/microclimate/core/internal/MicroclimateApplication.java
+++ b/dev/com.ibm.microclimate.core/src/com/ibm/microclimate/core/internal/MicroclimateApplication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -96,11 +96,16 @@ public class MicroclimateApplication {
 	
 	public synchronized void setBuildStatus(String buildStatus, String buildDetails) {
 		if (buildStatus != null) {
-			this.buildStatus = BuildStatus.get(buildStatus);
+			BuildStatus newStatus = BuildStatus.get(buildStatus);
+			boolean hasChanged = newStatus != this.buildStatus;
+			this.buildStatus = newStatus;
 			if (buildDetails != null && buildDetails.trim().isEmpty()) {
 				this.buildDetails = null;
 			} else {
 				this.buildDetails = buildDetails;
+			}
+			if (hasChanged && newStatus.isComplete()) {
+				buildComplete();
 			}
 		}
 	}
@@ -271,6 +276,10 @@ public class MicroclimateApplication {
 	public boolean supportsDebug() {
 		// Override as needed
 		return false;
+	}
+	
+	public void buildComplete() {
+		// Override to perform actions when a build has completed
 	}
 
 	@Override

--- a/dev/com.ibm.microclimate.core/src/com/ibm/microclimate/core/internal/constants/BuildStatus.java
+++ b/dev/com.ibm.microclimate.core/src/com/ibm/microclimate/core/internal/constants/BuildStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -46,6 +46,10 @@ public enum BuildStatus {
 		}
 		MCLogger.logError("Unrecognized application state: " + buildStatus);
 		return BuildStatus.UNKOWN;
+	}
+	
+	public boolean isComplete() {
+		return this == SUCCESS || this == FAILED;
 	}
 	
 	public String getDisplayString() {

--- a/dev/com.ibm.microclimate.core/src/com/ibm/microclimate/core/internal/messages/Messages.java
+++ b/dev/com.ibm.microclimate.core/src/com/ibm/microclimate/core/internal/messages/Messages.java
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 package com.ibm.microclimate.core.internal.messages;
 
 import org.eclipse.osgi.util.NLS;
@@ -47,6 +58,9 @@ public class Messages extends NLS {
 	
 	public static String DebugLaunchError;
 	public static String ReconnectDebugJob;
+	
+	public static String RefreshResourceJobLabel;
+	public static String RefreshResourceError;
 
 	static {
 		// initialize resource bundle

--- a/dev/com.ibm.microclimate.core/src/com/ibm/microclimate/core/internal/messages/messages.properties
+++ b/dev/com.ibm.microclimate.core/src/com/ibm/microclimate/core/internal/messages/messages.properties
@@ -51,3 +51,6 @@ BuildStateUnknown=No build status information
 
 DebugLaunchError=An error occurred trying to launch the debugger for the {0} project.
 ReconnectDebugJob=Reconnect debugger
+
+RefreshResourceJobLabel=Refreshing resource: {0}
+RefreshResourceError=An error occurred while trying to refresh the {0} resource.

--- a/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/marker/MicroclimateMarkerResolution.java
+++ b/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/marker/MicroclimateMarkerResolution.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -50,7 +50,7 @@ public class MicroclimateMarkerResolution implements IMarkerResolution {
 			app.mcConnection.requestValidateGenerate(app);
 			IResource resource = marker.getResource();
 			if (resource != null) {
-				Job job = new Job(Messages.refreshResourceJobLabel) {
+				Job job = new Job(NLS.bind(Messages.refreshResourceJobLabel, resource.getName())) {
 					@Override
 					protected IStatus run(IProgressMonitor monitor) {
 						try {

--- a/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/messages/Messages.java
+++ b/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/messages/Messages.java
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 package com.ibm.microclimate.ui.internal.messages;
 
 import org.eclipse.osgi.util.NLS;

--- a/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/messages/messages.properties
+++ b/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/messages/messages.properties
@@ -62,7 +62,7 @@ ActionNewConnection=&New Microclimate Connection
 
 ValidateLabel=Validate
 AttachDebuggerLabel=A&ttach Debugger
-refreshResourceJobLabel=Refresh resource
+refreshResourceJobLabel=Refreshing resource: {0}
 RefreshResourceError=An error occurred while trying to refresh the {0} resource.
 
 ImportProjectError=An error occurred while importing the {0} project.


### PR DESCRIPTION
Fixes #15 

When a build is complete, refresh the associated project if it exists.