### PR TITLE
Issue #37: Change attach debugger label for Node.js projects

### DIFF
--- a/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/actions/AttachDebuggerAction.java
+++ b/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/actions/AttachDebuggerAction.java
@@ -18,6 +18,7 @@ import org.eclipse.ui.actions.SelectionProviderAction;
 import com.ibm.microclimate.core.internal.MCEclipseApplication;
 import com.ibm.microclimate.core.internal.MCLogger;
 import com.ibm.microclimate.core.internal.constants.AppState;
+import com.ibm.microclimate.core.internal.constants.ProjectType;
 import com.ibm.microclimate.core.internal.constants.StartMode;
 import com.ibm.microclimate.ui.internal.messages.Messages;
 
@@ -41,6 +42,11 @@ public class AttachDebuggerAction extends SelectionProviderAction {
 			Object obj = sel.getFirstElement();
 			if (obj instanceof MCEclipseApplication) {
             	app = (MCEclipseApplication) obj;
+            	if (app.projectType.isLanguage(ProjectType.LANGUAGE_NODEJS)) {
+            		this.setText(Messages.LaunchDebugSessionLabel);
+            	} else {
+            		this.setText(Messages.AttachDebuggerLabel);
+            	}
             	if (app.isAvailable() && StartMode.DEBUG_MODES.contains(app.getStartMode()) && app.getDebugPort() != -1 &&
             			(app.getAppState() == AppState.STARTED || app.getAppState() == AppState.STARTING)) {
             		setEnabled(app.canAttachDebugger());

--- a/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/messages/Messages.java
+++ b/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/messages/Messages.java
@@ -69,6 +69,7 @@ public class Messages extends NLS {
 	
 	public static String ValidateLabel;
 	public static String AttachDebuggerLabel;
+	public static String LaunchDebugSessionLabel;
 	public static String refreshResourceJobLabel;
 	public static String RefreshResourceError;
 	

--- a/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/messages/messages.properties
+++ b/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/messages/messages.properties
@@ -62,6 +62,7 @@ ActionNewConnection=&New Microclimate Connection
 
 ValidateLabel=Validate
 AttachDebuggerLabel=A&ttach Debugger
+LaunchDebugSessionLabel=&Launch Debug Session
 refreshResourceJobLabel=Refreshing resource: {0}
 RefreshResourceError=An error occurred while trying to refresh the {0} resource.
 


### PR DESCRIPTION
Fixes #37 

Change the Attach Debugger label for Node.js projects to something that better represents what is really happening (it "helps" launch a debug session in a Chromium based browser).