### PR TITLE
Issue #50: Disable workspace auto build to speed up tests

### DIFF
--- a/dev/com.ibm.microclimate.test/src/com/ibm/microclimate/test/BaseAutoBuildTest.java
+++ b/dev/com.ibm.microclimate.test/src/com/ibm/microclimate/test/BaseAutoBuildTest.java
@@ -81,11 +81,7 @@ public abstract class BaseAutoBuildTest extends BaseTest {
     
     @Test
     public void test99_tearDown() {
-    	try {
-			MicroclimateUtil.cleanup(connection);
-		} catch (Exception e) {
-			TestUtil.print("Test case cleanup failed", e);
-		}
+    	doTearDown();
     	TestUtil.print("Ending test: " + getName());
     }
 

--- a/dev/com.ibm.microclimate.test/src/com/ibm/microclimate/test/BaseDebugTest.java
+++ b/dev/com.ibm.microclimate.test/src/com/ibm/microclimate/test/BaseDebugTest.java
@@ -87,11 +87,7 @@ public abstract class BaseDebugTest extends BaseTest {
     
     @Test
     public void test99_tearDown() {
-    	try {
-			MicroclimateUtil.cleanup(connection);
-		} catch (Exception e) {
-			TestUtil.print("Test case cleanup failed", e);
-		}
+    	doTearDown();
     	TestUtil.print("Ending test: " + getName());
     }
 

--- a/dev/com.ibm.microclimate.test/src/com/ibm/microclimate/test/BaseValidationTest.java
+++ b/dev/com.ibm.microclimate.test/src/com/ibm/microclimate/test/BaseValidationTest.java
@@ -84,11 +84,7 @@ public abstract class BaseValidationTest extends BaseTest {
 
     @Test
     public void test99_tearDown() {
-    	try {
-			MicroclimateUtil.cleanup(connection);
-		} catch (Exception e) {
-			TestUtil.print("Test case cleanup failed", e);
-		}
+    	doTearDown();
     	TestUtil.print("Ending test: " + getName());
     }
     


### PR DESCRIPTION
Fixes #50 

Disable workspace auto build in test cases so they run a bit faster.