### PR TITLE
ICP: Fixes for synchronization cleanup

### DIFF
--- a/dev/com.ibm.microclimate.core/src/com/ibm/microclimate/core/MicroclimateCorePlugin.java
+++ b/dev/com.ibm.microclimate.core/src/com/ibm/microclimate/core/MicroclimateCorePlugin.java
@@ -24,6 +24,7 @@ import com.ibm.microclimate.core.internal.IDebugLauncher;
 import com.ibm.microclimate.core.internal.IUpdateHandler;
 import com.ibm.microclimate.core.internal.MCEclipseApplication;
 import com.ibm.microclimate.core.internal.MCLogger;
+import com.ibm.microclimate.core.internal.MCResourceChangeListener;
 import com.ibm.microclimate.core.internal.PlatformUtil;
 import com.ibm.microclimate.core.internal.remote.SyncUtils;
 import com.ibm.microclimate.core.internal.remote.Syncthing;
@@ -79,7 +80,7 @@ public class MicroclimateCorePlugin extends AbstractUIPlugin {
 		getPreferenceStore().setDefault(DEBUG_CONNECT_TIMEOUT_PREFSKEY,
 				MCEclipseApplication.DEFAULT_DEBUG_CONNECT_TIMEOUT);
 		
-//		startSyncthing();
+		MCResourceChangeListener.start();
 	}
 
 	/*
@@ -88,6 +89,7 @@ public class MicroclimateCorePlugin extends AbstractUIPlugin {
 	 */
 	@Override
 	public void stop(BundleContext context) throws Exception {
+		MCResourceChangeListener.stop();
 		stopSyncthing();
 		plugin = null;
 		super.stop(context);

--- a/dev/com.ibm.microclimate.core/src/com/ibm/microclimate/core/internal/MCResourceChangeListener.java
+++ b/dev/com.ibm.microclimate.core/src/com/ibm/microclimate/core/internal/MCResourceChangeListener.java
@@ -107,21 +107,13 @@ public class MCResourceChangeListener implements IResourceChangeListener {
         	
 			for (MicroclimateApplication app : toBeRemovedApps) {
 				MCLogger.log("Application " + app.name + " removed. Stop any synchronization.");
-				Job job = new Job(NLS.bind(Messages.ICPStopSyncJob, app.name)) {
-
-					@Override
-					protected IStatus run(IProgressMonitor arg0) {
-						// Call method to remove - does nothing if not synced
-						try {
-							ICPSyncManager.removeLocalProject(app);
-							return Status.OK_STATUS;
-						} catch (Exception e) {
-							MCLogger.logError("Failed to stop synchronization for microclimate ICP project: " + app.name, e);
-							return new Status(IStatus.ERROR, MicroclimateCorePlugin.PLUGIN_ID, NLS.bind(Messages.ICPStopSyncFailed, app.name));
-						}
-					}
-				};
-				job.schedule();
+				// Don't handle removes in a job as the synchronization needs to be stopped before the project is removed
+				try {
+					// Call method to remove - does nothing if not synced
+					ICPSyncManager.removeLocalProject(app);
+				} catch (Exception e) {
+					MCLogger.logError("Failed to stop synchronization for microclimate ICP project: " + app.name, e);
+				}
 			}
 			
 			for (MicroclimateApplication app : changedApps) {
@@ -143,7 +135,7 @@ public class MCResourceChangeListener implements IResourceChangeListener {
 							}
 						case LOCAL_CONNECTION:
 							try {
-								app.mcConnection.requestProjectBuild(app, MCConstants.VALUE_ACTION_BUILD);
+//								app.mcConnection.requestProjectBuild(app, MCConstants.VALUE_ACTION_BUILD);
 								return Status.OK_STATUS;
 							} catch (Exception e) {
 								MCLogger.logError("Failed to start a build for microclimate project: " + app.name, e);

--- a/dev/com.ibm.microclimate.core/src/com/ibm/microclimate/core/internal/MicroclimateObjectFactory.java
+++ b/dev/com.ibm.microclimate.core/src/com/ibm/microclimate/core/internal/MicroclimateObjectFactory.java
@@ -33,8 +33,8 @@ public class MicroclimateObjectFactory {
 		return connection;
 	}
 	
-	public static ICPMicroclimateConnection createICPConnection(URI ingressURI, String masterIP) throws Exception {
-		ICPMicroclimateConnection connection = new ICPMicroclimateConnection(ingressURI, masterIP);
+	public static ICPMicroclimateConnection createICPConnection(URI ingressURI, String masterIP, String namespace) throws Exception {
+		ICPMicroclimateConnection connection = new ICPMicroclimateConnection(ingressURI, masterIP, namespace);
 		connection.initialize();
 		return connection;
 	}

--- a/dev/com.ibm.microclimate.core/src/com/ibm/microclimate/core/internal/connection/ICPSyncManager.java
+++ b/dev/com.ibm.microclimate.core/src/com/ibm/microclimate/core/internal/connection/ICPSyncManager.java
@@ -40,13 +40,11 @@ public class ICPSyncManager {
 	private static final String PROJECTS_KEY = "projects";
 	
 	
-	public static String setupLocalProject(MicroclimateApplication app) throws Exception {
+	public static String setupLocalProject(ICPMicroclimateConnection conn, MicroclimateApplication app) throws Exception {
 		Syncthing syncthing = getSyncthing();
 		
 		// Set up synchronization for the application
-		String host = app.mcConnection.getHost();
-		String namespace = app.mcConnection.getSocketNamespace();
-		String localFolder = syncthing.shareICPFolder(host, namespace, app.name);
+		String localFolder = syncthing.shareICPFolder(conn.getMasterIP(), conn.getNamespace(), app.name);
 		addSyncedProject(app);
 		return localFolder;
 	}
@@ -139,7 +137,7 @@ public class ICPSyncManager {
 		JSONArray connections = pref.getJSONArray(CONNECTIONS_KEY);
 		for (int connIndex = 0; connIndex < connections.length(); connIndex++) {
 			JSONObject connection = connections.getJSONObject(connIndex);
-			if (app.mcConnection.baseUrl.equals(connection.get(URI_KEY))) {
+			if (app.mcConnection.baseUrl.toString().equals(connection.get(URI_KEY))) {
 				JSONArray projects = connection.getJSONArray(PROJECTS_KEY);
 				for (int projIndex = 0; projIndex < projects.length(); projIndex++) {
 					if (app.name.equals(projects.getString(projIndex))) {
@@ -174,7 +172,7 @@ public class ICPSyncManager {
 	}
 	
 	private static void addSyncedProject(MicroclimateApplication app) throws JSONException {
-		URI uri = app.mcConnection.baseUrl;
+		String uri = app.mcConnection.baseUrl.toString();
 		String projectName = app.name;
 		
 		JSONObject pref = getSyncedProjectsValue();
@@ -206,7 +204,7 @@ public class ICPSyncManager {
 	}
 	
 	private static void removeSyncedProject(MicroclimateApplication app) throws JSONException {
-		URI uri = app.mcConnection.baseUrl;
+		String uri = app.mcConnection.baseUrl.toString();
 		String projectName = app.name;
 		
 		JSONObject pref = getSyncedProjectsValue();
@@ -230,7 +228,7 @@ public class ICPSyncManager {
 	}
 	
 	private static JSONArray removeConnection(MicroclimateConnection conn) throws JSONException {
-		URI uri = conn.baseUrl;
+		String uri = conn.baseUrl.toString();
 		JSONArray projects = null;
 		
 		JSONObject pref = getSyncedProjectsValue();

--- a/dev/com.ibm.microclimate.core/src/com/ibm/microclimate/core/internal/remote/Syncthing.java
+++ b/dev/com.ibm.microclimate.core/src/com/ibm/microclimate/core/internal/remote/Syncthing.java
@@ -134,21 +134,9 @@ public class Syncthing {
 		Thread thread = new Thread(eventMonitor);
 		thread.setDaemon(true);
 		thread.start();
-		
-//		try {
-//			String folderName = "node20a";
-//			String host = "xxx.xxx.xxx.xxx";
-//			String namespace = "mcf";
-//			shareICPFolder(host, namespace, folderName);
-//			scanFolder(folderName);
-//			stopSharingFolder(folderName);
-//			scanFolder(folderName);
-//		} catch (Exception e) {
-//			e.printStackTrace();
-//		}
 	}
 	
-	// Stop Syncthing and stop the event monitor
+	// Stop Syncthing and the event monitor
 	public void stop() throws IOException {
 		if (eventMonitor != null) {
 			eventMonitor.stopMonitor();

--- a/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/messages/Messages.java
+++ b/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/messages/Messages.java
@@ -74,6 +74,7 @@ public class Messages extends NLS {
 	public static String refreshResourceJobLabel;
 	public static String RefreshResourceError;
 	
+	public static String ImportProjectJobLabel;
 	public static String ImportProjectError;
 	public static String StartBuildError;
 	public static String OpenMicroclimateUIError;

--- a/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/messages/messages.properties
+++ b/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/messages/messages.properties
@@ -67,6 +67,7 @@ LaunchDebugSessionLabel=&Launch Debug Session
 refreshResourceJobLabel=Refreshing resource: {0}
 RefreshResourceError=An error occurred while trying to refresh the {0} resource.
 
+ImportProjectJobLabel=Importing project: {0}
 ImportProjectError=An error occurred while importing the {0} project.
 StartBuildError=An error occurred while starting a build for the {0} project.
 OpenMicroclimateUIError=An error occurred while opening the Microclimate UI.

--- a/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/wizards/ICPConnectionComposite.java
+++ b/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/wizards/ICPConnectionComposite.java
@@ -38,7 +38,7 @@ import com.ibm.microclimate.ui.internal.views.ViewHelper;
 
 public class ICPConnectionComposite extends ConnectionComposite {
 	
-	private Text masterIPText, ingressURLText;
+	private Text masterIPText, ingressURLText, namespaceText;
 	
 	public ICPConnectionComposite(Composite parent, WizardPage wizardPage) {
 		super(parent, wizardPage);
@@ -70,6 +70,14 @@ public class ICPConnectionComposite extends ConnectionComposite {
 		ingressURLText = new Text(composite, SWT.BORDER);
 		ingressURLText.setText("https://microclimate.9.42.41.81.nip.io");
 		ingressURLText.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, false));
+		
+		Label namespaceLabel = new Label(composite, SWT.NONE);
+		namespaceLabel.setText("Namespace:");
+		namespaceLabel.setLayoutData(new GridData(GridData.FILL, GridData.CENTER, false, false));
+		
+		namespaceText = new Text(composite, SWT.BORDER);
+		namespaceText.setText("mcg");
+		namespaceText.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, false));
 	}
 
 	@Override
@@ -87,6 +95,7 @@ public class ICPConnectionComposite extends ConnectionComposite {
 	protected void performFinish() {
 		final String masterIP = masterIPText.getText();
 		final String ingressURL = ingressURLText.getText();
+		final String namespace = namespaceText.getText();
 		Job job = new Job("Connect to host: " + masterIP) {
 			@Override
 			protected IStatus run(IProgressMonitor arg0) {
@@ -133,7 +142,7 @@ public class ICPConnectionComposite extends ConnectionComposite {
 
 				// Will throw an Exception if fails
 				try {
-					final MicroclimateConnection connection = MicroclimateObjectFactory.createICPConnection(uri, masterIP);
+					final MicroclimateConnection connection = MicroclimateObjectFactory.createICPConnection(uri, masterIP, namespace);
 					MicroclimateConnectionManager.add(connection);
 					Display.getDefault().syncExec(new Runnable() {
 		                @Override


### PR DESCRIPTION
- Fixes for synchronization cleanup
- Add the resource listener on plugin startup
- ICP connections need the namespace as well