### PR TITLE
Issue #62: Remove Next button from new connection wizard

### DIFF
--- a/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/wizards/NewMicroclimateConnectionPage.java
+++ b/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/wizards/NewMicroclimateConnectionPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -209,11 +209,6 @@ public class NewMicroclimateConnectionPage extends WizardPage {
 	 */
 	MicroclimateConnection getMCConnection() {
 		return mcConnection;
-	}
-
-	@Override
-	public boolean canFlipToNextPage() {
-		return mcConnection != null;
 	}
 
 	void performFinish() {


### PR DESCRIPTION
Fixes #62 

Make sure the Next button does not show in the new connection wizard.