### PR TITLE
Issue #89: Use new project create API for tests if available

### DIFF
--- a/dev/com.ibm.microclimate.core/src/com/ibm/microclimate/core/internal/console/ProjectTemplateInfo.java
+++ b/dev/com.ibm.microclimate.core/src/com/ibm/microclimate/core/internal/console/ProjectTemplateInfo.java
@@ -59,4 +59,9 @@ public class ProjectTemplateInfo {
 		return value;
 	}
 
+	@Override
+	public String toString() {
+		return projectInfo.toString();
+	}
+
 }

--- a/dev/com.ibm.microclimate.core/src/com/ibm/microclimate/core/internal/constants/ProjectType.java
+++ b/dev/com.ibm.microclimate.core/src/com/ibm/microclimate/core/internal/constants/ProjectType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -45,6 +45,11 @@ public class ProjectType {
 	
 	public boolean isLanguage(String language) {
 		return language != null && language.equals(this.language);
+	}
+
+	@Override
+	public String toString() {
+		return ("Project type: " + type + ", project language: " + language);
 	}
 
 }


### PR DESCRIPTION
If the new project create API is available then use it.  Leave the old one for testing with older versions of Microclimate.