### PR TITLE
Issue #157: Refresh projects on change event

### DIFF
--- a/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/messages/Messages.java
+++ b/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/messages/Messages.java
@@ -146,6 +146,7 @@ public class Messages extends NLS {
 	public static String NewProjectPage_ImportLabel;
 	public static String NewProjectPage_ProjectNameLabel;
 	public static String NewProjectPage_ProjectExistsError;
+	public static String NewProjectPage_EclipseProjectExistsError;
 	public static String NewProjectPage_InvalidProjectName;
 	public static String NewProjectPage_ProjectCreateErrorTitle;
 	public static String NewProjectPage_ProjectCreateErrorMsg;

--- a/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/messages/messages.properties
+++ b/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/messages/messages.properties
@@ -139,6 +139,7 @@ NewProjectPage_DescriptionNone=<none>
 NewProjectPage_ImportLabel=Import project after it is created
 NewProjectPage_ProjectNameLabel=Project name:
 NewProjectPage_ProjectExistsError=A Microclimate project named {0} already exists. Choose a unique name.
+NewProjectPage_EclipseProjectExistsError=The import button is selected but an Eclipse project named {0} already exists. Choose a unique name.
 NewProjectPage_InvalidProjectName=Use only lower case letters and numbers in the project name.
 NewProjectPage_ProjectCreateErrorTitle=Project Create Error
 NewProjectPage_ProjectCreateErrorMsg=An error occurred trying to create Microclimate project {0}: {1}

--- a/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/wizards/NewMicroclimateProjectPage.java
+++ b/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/wizards/NewMicroclimateProjectPage.java
@@ -15,6 +15,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.jface.viewers.ColumnWeightData;
 import org.eclipse.jface.viewers.TableLayout;
 import org.eclipse.jface.wizard.WizardPage;
@@ -234,9 +236,17 @@ public class NewMicroclimateProjectPage extends WizardPage {
 		if (!projectNamePattern.matcher(projectName).matches()) {
 			setErrorMessage(Messages.NewProjectPage_InvalidProjectName);
 			return false;
-		} else if (connection.getAppByName(projectName) != null) {
+		}
+		if (connection.getAppByName(projectName) != null) {
 			setErrorMessage(NLS.bind(Messages.NewProjectPage_ProjectExistsError, projectName));
 			return false;
+		}
+		if (importButton.getSelection()) {
+			IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
+			if (project != null && project.exists()) {
+				setErrorMessage(NLS.bind(Messages.NewProjectPage_EclipseProjectExistsError, projectName));
+				return false;
+			}
 		}
 		setErrorMessage(null);
 		return selectionTable.getSelectionCount() == 1 && projectName != null && !projectName.isEmpty();

--- a/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/wizards/NewMicroclimateProjectWizard.java
+++ b/dev/com.ibm.microclimate.ui/src/com/ibm/microclimate/ui/internal/wizards/NewMicroclimateProjectWizard.java
@@ -13,6 +13,8 @@ package com.ibm.microclimate.ui.internal.wizards;
 
 import java.util.List;
 
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.widgets.Display;
@@ -74,9 +76,17 @@ public class NewMicroclimateProjectWizard extends Wizard {
 								}
 							});
 							if (importProject) {
-								ImportProjectAction.importProject(app);
+								IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(app.name);
+								if (project == null || !project.exists()) {
+									ImportProjectAction.importProject(app);
+								} else {
+									// This should not happen since the wizard checks for this
+									MCLogger.logError("The project cannot be imported because a project already exists with the name: " + app.name);
+								}
 							}
 							return;
+						} else {
+							MCLogger.logError("An import operation was requested but the application could not be found for: " + name);
 						}
 					}
 				}


### PR DESCRIPTION
Fixes #157 

Refresh projects on a change event if a project cannot be found that matches the project id.